### PR TITLE
fixing uri and adding log

### DIFF
--- a/android/src/main/kotlin/com/fluttercavalry/fc_native_video_thumbnail/FcNativeVideoThumbnailPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercavalry/fc_native_video_thumbnail/FcNativeVideoThumbnailPlugin.kt
@@ -73,7 +73,7 @@ class FcNativeVideoThumbnailPlugin: FlutterPlugin, MethodCallHandler {
             var scaled = false
             if (srcFileUri) {
               val mmr = MediaMetadataRetriever()
-              mmr.setDataSource(mContext, Uri.parse(srcFile))
+              mmr.setDataSource(srcFile, hashMapOf())
               if (Build.VERSION.SDK_INT >= 27) {
                 bitmap = mmr.getScaledFrameAtTime(-1, OPTION_CLOSEST_SYNC, width, height)
                 scaled = true
@@ -120,6 +120,7 @@ class FcNativeVideoThumbnailPlugin: FlutterPlugin, MethodCallHandler {
             }
           } catch (err: Exception) {
             launch(Dispatchers.Main) {
+              android.util.Log.e("PluginErrir", "getVideoThumbnail failed", err);
               result.error("PluginError", err.message, null)
             }
           }


### PR DESCRIPTION
# What is this?

tl&dr: Fixing the code so we can retrieve it by url + adding log so we can actually see if there are any errors

"Long" story:

I tried to use this plugin, but I couldn't get it work when using it from URI.
I got an error saying access denied.

I had to clone it and add the log message to see the actual details on why it failed - and it seems it was trying to retrieve it as file, even though the boolean was set.

Looked online and the fix is to call another method, which is what I did