### PR TITLE
Add Linux platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 A Flutter plugin to create video thumbnails via native APIs.
 
-|               | iOS | Android | macOS | Windows |
-| ------------- | --- | ------- | ----- | ------- |
-| Source (Path) | ✅  | ✅      | ✅    | ✅      |
-| Source (Uri)  | ✅  | ✅      | ✅    | -       |
-| Seeking       | ✅  | ⚠️      | ✅    | -       |
+|               | iOS | Android | macOS | Windows | Linux |
+| ------------- | --- | ------- | ----- | ------- | ----- |
+| Source (Path) | ✅  | ✅      | ✅    | ✅      | ✅    |
+| Source (Uri)  | ✅  | ✅      | ✅    | -       | -     |
+| Seeking       | ✅  | ⚠️      | ✅    | -       | ✅    |
 
 ⚠️ Android seeking is only supported when the source file is a Uri.
+
+Linux requires `libavformat`, `libavcodec`, `libavutil`, `libswscale` (FFmpeg) and `libjpeg` installed on the system.
 
 ## Usage
 

--- a/example/.metadata
+++ b/example/.metadata
@@ -1,0 +1,30 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "00b0c91f06209d9e4a41f71b7a512d6eb3b9c694"
+  channel: "stable"
+
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: 00b0c91f06209d9e4a41f71b7a512d6eb3b9c694
+      base_revision: 00b0c91f06209d9e4a41f71b7a512d6eb3b9c694
+    - platform: linux
+      create_revision: 00b0c91f06209d9e4a41f71b7a512d6eb3b9c694
+      base_revision: 00b0c91f06209d9e4a41f71b7a512d6eb3b9c694
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:fc_native_video_thumbnail/fc_native_video_thumbnail.dart';
+import 'package:fc_native_video_thumbnail/fc_native_video_thumbnail_platform_interface.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -36,10 +37,12 @@ class Task {
   String? outFile;
   String? outFileDimensions;
   String? outFileError;
+  Duration? outFileTime;
 
   Uint8List? outBytes;
   String? outBytesDimensions;
   String? outBytesError;
+  Duration? outBytesTime;
 
   Task({
     required this.name,
@@ -54,6 +57,7 @@ class Task {
   }
 
   Future<void> _toFile() async {
+    final sw = Stopwatch()..start();
     try {
       final destFile = tmpPath() + p.extension(srcFile);
       await _plugin.saveThumbnailToFile(
@@ -77,10 +81,14 @@ class Task {
       }
     } catch (err) {
       outFileError = err.toString();
+    } finally {
+      sw.stop();
+      outFileTime = sw.elapsed;
     }
   }
 
   Future<void> _toBytes() async {
+    final sw = Stopwatch()..start();
     try {
       final bytes = await _plugin.saveThumbnailToBytes(
         srcFile: srcFile,
@@ -99,6 +107,9 @@ class Task {
       }
     } catch (err) {
       outBytesError = err.toString();
+    } finally {
+      sw.stop();
+      outBytesTime = sw.elapsed;
     }
   }
 }
@@ -114,6 +125,14 @@ enum _VideoSrc { gallery, files, uri }
 
 class _MyHomeState extends State<MyHome> {
   final _tasks = <Task>[];
+  String? _selectedVideoPath;
+  bool? _isSrcUri;
+  double _seekPosition = 0.0;
+  double _maxDuration = 60.0;
+  Timer? _debounceTimer;
+  Uint8List? _seekThumbnail;
+  String? _seekThumbnailError;
+  bool _seeking = false;
 
   @override
   Widget build(BuildContext context) {
@@ -142,6 +161,44 @@ class _MyHomeState extends State<MyHome> {
                   onPressed: () => _selectVideo(.uri),
                   child: const Text('Select video from SAF (URI)'),
                 ),
+              if (!Platform.isWindows && _selectedVideoPath != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  'Seek to: ${_seekPosition.toStringAsFixed(1)}s',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                Slider(
+                  value: _seekPosition,
+                  min: 0,
+                  max: _maxDuration,
+                  divisions: _maxDuration.toInt() * 10,
+                  label: '${_seekPosition.toStringAsFixed(1)}s',
+                  onChanged: (value) {
+                    setState(() {
+                      _seekPosition = value;
+                    });
+                    _debounceTimer?.cancel();
+                    _debounceTimer = Timer(const Duration(milliseconds: 100), () {
+                      _generateSeekThumbnail();
+                    });
+                  },
+                ),
+                if (_seeking)
+                  const SizedBox(
+                    width: 300,
+                    height: 200,
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                if (_seekThumbnail != null)
+                  SizedBox(
+                    width: 300,
+                    height: 200,
+                    child: Image.memory(_seekThumbnail!),
+                  ),
+                if (_seekThumbnailError != null)
+                  Text(_seekThumbnailError!, style: const TextStyle(color: Colors.red)),
+              ],
+              const SizedBox(height: 8),
               ..._tasks.map((task) {
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -156,6 +213,8 @@ class _MyHomeState extends State<MyHome> {
                       ),
                     ),
                     Text('Out file: ${task.outFile}'),
+                    if (task.outFileTime != null)
+                      Text('Time: ${task.outFileTime!.inMilliseconds}ms'),
                     if (task.outFileError != null) ...[
                       Text(
                         task.outFileError!,
@@ -169,6 +228,8 @@ class _MyHomeState extends State<MyHome> {
                     Text(
                       'Out bytes: ${task.outBytes != null ? '${task.outBytes!.lengthInBytes} bytes' : 'null'}',
                     ),
+                    if (task.outBytesTime != null)
+                      Text('Time: ${task.outBytesTime!.inMilliseconds}ms'),
                     if (task.outBytesError != null) ...[
                       Text(
                         task.outBytesError!,
@@ -220,6 +281,11 @@ class _MyHomeState extends State<MyHome> {
 
       setState(() {
         _tasks.clear();
+        _selectedVideoPath = srcPath;
+        _isSrcUri = src == _VideoSrc.uri ? true : null;
+        _seekPosition = 0.0;
+        _seekThumbnail = null;
+        _seekThumbnailError = null;
       });
 
       final smallVidBytes = await rootBundle.load('res/a.mp4');
@@ -255,6 +321,44 @@ class _MyHomeState extends State<MyHome> {
         return;
       }
       await _showErrorAlert(context, err.toString());
+    }
+  }
+
+  Future<void> _generateSeekThumbnail() async {
+    if (_selectedVideoPath == null) return;
+    setState(() {
+      _seeking = true;
+      _seekThumbnail = null;
+      _seekThumbnailError = null;
+    });
+    try {
+      final bytes = await _plugin.saveThumbnailToBytes(
+        srcFile: _selectedVideoPath!,
+        width: 300,
+        height: 300,
+        srcFileUri: _isSrcUri,
+        at: FcVideoThumbnailTime(
+          (_seekPosition * 1e6).toInt(),
+          FcVideoThumbnailTimeUnit.microseconds,
+        ),
+      );
+      if (bytes != null) {
+        setState(() {
+          _seekThumbnail = bytes;
+        });
+      } else {
+        setState(() {
+          _seekThumbnailError = 'No thumbnail at this position';
+        });
+      }
+    } catch (err) {
+      setState(() {
+        _seekThumbnailError = err.toString();
+      });
+    } finally {
+      setState(() {
+        _seeking = false;
+      });
     }
   }
 

--- a/example/linux/.gitignore
+++ b/example/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/example/linux/CMakeLists.txt
+++ b/example/linux/CMakeLists.txt
@@ -1,0 +1,128 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "fc_native_video_thumbnail_example")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+set(APPLICATION_ID "com.fluttercavalry.fc_native_video_thumbnail_example")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/example/linux/flutter/CMakeLists.txt
+++ b/example/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,19 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <fc_native_video_thumbnail/fc_native_video_thumbnail_plugin.h>
+#include <file_selector_linux/file_selector_plugin.h>
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) fc_native_video_thumbnail_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FcNativeVideoThumbnailPlugin");
+  fc_native_video_thumbnail_plugin_register_with_registrar(fc_native_video_thumbnail_registrar);
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+}

--- a/example/linux/flutter/generated_plugin_registrant.h
+++ b/example/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,25 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  fc_native_video_thumbnail
+  file_selector_linux
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/example/linux/runner/CMakeLists.txt
+++ b/example/linux/runner/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# Define the application target. To change its name, change BINARY_NAME in the
+# top-level CMakeLists.txt, not the value here, or `flutter run` will no longer
+# work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add preprocessor definitions for the application ID.
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/example/linux/runner/main.cc
+++ b/example/linux/runner/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/example/linux/runner/my_application.cc
+++ b/example/linux/runner/my_application.cc
@@ -1,0 +1,148 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Called when first Flutter frame received.
+static void first_frame_cb(MyApplication* self, FlView* view) {
+  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "fc_native_video_thumbnail_example");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "fc_native_video_thumbnail_example");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000
+  // for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  // Show the window when Flutter renders.
+  // Requires the view to be realized so we can start rendering.
+  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
+                           self);
+  gtk_widget_realize(GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application,
+                                                  gchar*** arguments,
+                                                  int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, "flags",
+                                     G_APPLICATION_NON_UNIQUE, nullptr));
+}

--- a/example/linux/runner/my_application.h
+++ b/example/linux/runner/my_application.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication,
+                     my_application,
+                     MY,
+                     APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,7 +79,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.1"
   file:
     dependency: transitive
     description:

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,0 +1,113 @@
+# The Flutter tooling requires that developers have CMake 3.10 or later
+# installed. You should not increase this version, as doing so will cause
+# the plugin to fail to compile for some customers of the plugin.
+cmake_minimum_required(VERSION 3.10)
+
+# Project-level configuration.
+set(PROJECT_NAME "fc_native_video_thumbnail")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# This value is used when generating builds using this plugin, so it must
+# not be changed.
+set(PLUGIN_NAME "fc_native_video_thumbnail_plugin")
+
+# Any new source files that you add to the plugin should be added here.
+list(APPEND PLUGIN_SOURCES
+  "fc_native_video_thumbnail_plugin.cc"
+)
+
+# Define the plugin library target. Its name must not be changed (see comment
+# on PLUGIN_NAME above).
+add_library(${PLUGIN_NAME} SHARED
+  ${PLUGIN_SOURCES}
+)
+
+# Apply a standard set of build settings that are configured in the
+# application-level CMakeLists.txt. This can be removed for plugins that want
+# full control over build settings.
+apply_standard_settings(${PLUGIN_NAME})
+
+# Symbols are hidden by default to reduce the chance of accidental conflicts
+# between plugins. This should not be removed; any symbols that should be
+# exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+
+# Source include directories and library dependencies. Add any plugin-specific
+# dependencies here.
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+
+# FFmpeg dependencies
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(FFMPEG REQUIRED
+  libavformat
+  libavcodec
+  libavutil
+  libswscale
+)
+target_include_directories(${PLUGIN_NAME} PRIVATE ${FFMPEG_INCLUDE_DIRS})
+target_link_libraries(${PLUGIN_NAME} PRIVATE ${FFMPEG_LIBRARIES})
+target_link_directories(${PLUGIN_NAME} PRIVATE ${FFMPEG_LIBRARY_DIRS})
+
+# libjpeg dependency
+find_package(JPEG REQUIRED)
+target_include_directories(${PLUGIN_NAME} PRIVATE ${JPEG_INCLUDE_DIRS})
+target_link_libraries(${PLUGIN_NAME} PRIVATE ${JPEG_LIBRARIES})
+
+# List of absolute paths to libraries that should be bundled with the plugin.
+# This list could contain prebuilt libraries, or libraries created by an
+# external build triggered from this build file.
+set(fc_native_video_thumbnail_bundled_libraries
+  ""
+  PARENT_SCOPE
+)
+
+# === Tests ===
+# These unit tests can be run from a terminal after building the example.
+
+# Only enable test builds when building the example (which sets this variable)
+# so that plugin clients aren't building the tests.
+if (${include_${PROJECT_NAME}_tests})
+if(${CMAKE_VERSION} VERSION_LESS "3.11.0")
+message("Unit tests require CMake 3.11.0 or later")
+else()
+set(TEST_RUNNER "${PROJECT_NAME}_test")
+enable_testing()
+
+# Add the Google Test dependency.
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/release-1.11.0.zip
+)
+# Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Disable install commands for gtest so it doesn't end up in the bundle.
+set(INSTALL_GTEST OFF CACHE BOOL "Disable installation of googletest" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+
+# The plugin's exported API is not very useful for unit testing, so build the
+# sources directly into the test binary rather than using the shared library.
+add_executable(${TEST_RUNNER}
+  test/fc_native_video_thumbnail_plugin_test.cc
+  ${PLUGIN_SOURCES}
+)
+apply_standard_settings(${TEST_RUNNER})
+target_include_directories(${TEST_RUNNER} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(${TEST_RUNNER} PRIVATE flutter)
+target_link_libraries(${TEST_RUNNER} PRIVATE PkgConfig::GTK)
+target_link_libraries(${TEST_RUNNER} PRIVATE ${FFMPEG_LIBRARIES} ${JPEG_LIBRARIES})
+target_include_directories(${TEST_RUNNER} PRIVATE ${FFMPEG_INCLUDE_DIRS} ${JPEG_INCLUDE_DIRS})
+target_link_libraries(${TEST_RUNNER} PRIVATE gtest_main gmock)
+
+# Enable automatic test discovery.
+include(GoogleTest)
+gtest_discover_tests(${TEST_RUNNER})
+
+endif()  # CMake version check
+endif()  # include_${PROJECT_NAME}_tests

--- a/linux/fc_native_video_thumbnail_plugin.cc
+++ b/linux/fc_native_video_thumbnail_plugin.cc
@@ -1,0 +1,581 @@
+#include "include/fc_native_video_thumbnail/fc_native_video_thumbnail_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <gio/gio.h>
+#include <gtk/gtk.h>
+
+#include <csetjmp>
+#include <cstring>
+#include <vector>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
+#include <libswscale/swscale.h>
+}
+#include <jpeglib.h>
+
+#include "fc_native_video_thumbnail_plugin_private.h"
+
+#define FC_NATIVE_VIDEO_THUMBNAIL_PLUGIN(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), fc_native_video_thumbnail_plugin_get_type(), \
+                              FcNativeVideoThumbnailPlugin))
+
+struct _FcNativeVideoThumbnailPlugin {
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE(FcNativeVideoThumbnailPlugin, fc_native_video_thumbnail_plugin, g_object_get_type())
+
+static const char* kErrorInvalidArgs = "InvalidArguments";
+static const char* kErrorPluginError = "PluginError";
+
+static FlMethodResponse* make_success_bool(bool value) {
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_bool(value)));
+}
+
+static FlMethodResponse* make_success_bytes(const uint8_t* data, size_t len) {
+  g_autoptr(FlValue) result = fl_value_new_uint8_list(data, len);
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(result));
+}
+
+static FlMethodResponse* make_error(const char* code, const char* message) {
+  return FL_METHOD_RESPONSE(fl_method_error_response_new(code, message, nullptr));
+}
+
+static FlMethodResponse* make_null_result() {
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
+}
+
+struct my_jpeg_error_mgr {
+  struct jpeg_error_mgr pub;
+  jmp_buf setjmp_buffer;
+};
+
+static void my_jpeg_error_exit(j_common_ptr cinfo) {
+  struct my_jpeg_error_mgr* myerr = (struct my_jpeg_error_mgr*)cinfo->err;
+  longjmp(myerr->setjmp_buffer, 1);
+}
+
+static int encode_jpeg_to_buffer(const uint8_t* rgb_data,
+                                  int width,
+                                  int height,
+                                  int quality,
+                                  uint8_t** out_buffer,
+                                  unsigned long* out_size) {
+  struct jpeg_compress_struct cinfo;
+  struct my_jpeg_error_mgr jerr;
+  jpeg_create_compress(&cinfo);
+  cinfo.err = jpeg_std_error(&jerr.pub);
+  jerr.pub.error_exit = my_jpeg_error_exit;
+  if (setjmp(jerr.setjmp_buffer)) {
+    jpeg_destroy_compress(&cinfo);
+    return -1;
+  }
+
+  uint8_t* buf = nullptr;
+  unsigned long buf_size = 0;
+  jpeg_mem_dest(&cinfo, &buf, &buf_size);
+
+  cinfo.image_width = width;
+  cinfo.image_height = height;
+  cinfo.input_components = 3;
+  cinfo.in_color_space = JCS_RGB;
+
+  jpeg_set_defaults(&cinfo);
+  jpeg_set_quality(&cinfo, quality, TRUE);
+
+  jpeg_start_compress(&cinfo, TRUE);
+
+  JSAMPROW row_pointer[1];
+  int row_stride = width * 3;
+  while (cinfo.next_scanline < cinfo.image_height) {
+    row_pointer[0] = const_cast<JSAMPROW>(rgb_data + cinfo.next_scanline * row_stride);
+    jpeg_write_scanlines(&cinfo, row_pointer, 1);
+  }
+
+  jpeg_finish_compress(&cinfo);
+  jpeg_destroy_compress(&cinfo);
+
+  *out_buffer = buf;
+  *out_size = buf_size;
+  return 0;
+}
+
+static int extract_thumbnail(const char* src_file,
+                              int max_width,
+                              int max_height,
+                              int quality,
+                              int64_t at_us,
+                              uint8_t** out_jpeg,
+                              unsigned long* out_jpeg_size) {
+  AVFormatContext* format_ctx = avformat_alloc_context();
+  if (!format_ctx) return -1;
+
+  int ret = avformat_open_input(&format_ctx, src_file, nullptr, nullptr);
+  if (ret < 0) {
+    avformat_free_context(format_ctx);
+    return -1;
+  }
+
+  ret = avformat_find_stream_info(format_ctx, nullptr);
+  if (ret < 0) {
+    avformat_close_input(&format_ctx);
+    return -1;
+  }
+
+  int video_stream_index = -1;
+  const AVCodec* codec = nullptr;
+  for (unsigned int i = 0; i < format_ctx->nb_streams; i++) {
+    if (format_ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      video_stream_index = (int)i;
+      codec = avcodec_find_decoder(format_ctx->streams[i]->codecpar->codec_id);
+      break;
+    }
+  }
+
+  if (video_stream_index < 0 || !codec) {
+    avformat_close_input(&format_ctx);
+    return -1;
+  }
+
+  AVCodecContext* codec_ctx = avcodec_alloc_context3(codec);
+  if (!codec_ctx) {
+    avformat_close_input(&format_ctx);
+    return -1;
+  }
+
+  ret = avcodec_parameters_to_context(codec_ctx, format_ctx->streams[video_stream_index]->codecpar);
+  if (ret < 0) {
+    avcodec_free_context(&codec_ctx);
+    avformat_close_input(&format_ctx);
+    return -1;
+  }
+
+  ret = avcodec_open2(codec_ctx, codec, nullptr);
+  if (ret < 0) {
+    avcodec_free_context(&codec_ctx);
+    avformat_close_input(&format_ctx);
+    return -1;
+  }
+
+  if (at_us > 0) {
+    int64_t seek_ts = av_rescale_q(at_us, AV_TIME_BASE_Q, format_ctx->streams[video_stream_index]->time_base);
+    ret = av_seek_frame(format_ctx, video_stream_index, seek_ts, AVSEEK_FLAG_BACKWARD);
+    if (ret < 0) {
+      ret = av_seek_frame(format_ctx, video_stream_index, seek_ts, AVSEEK_FLAG_ANY);
+      if (ret < 0) {
+        avcodec_free_context(&codec_ctx);
+        avformat_close_input(&format_ctx);
+        return -1;
+      }
+    }
+    avcodec_flush_buffers(codec_ctx);
+  }
+
+  AVFrame* frame = av_frame_alloc();
+  AVPacket* packet = av_packet_alloc();
+  if (!frame || !packet) {
+    av_packet_free(&packet);
+    av_frame_free(&frame);
+    avcodec_free_context(&codec_ctx);
+    avformat_close_input(&format_ctx);
+    return -1;
+  }
+
+  int frame_count = 0;
+
+  while (av_read_frame(format_ctx, packet) >= 0) {
+    if (packet->stream_index != video_stream_index) {
+      av_packet_unref(packet);
+      continue;
+    }
+
+    ret = avcodec_send_packet(codec_ctx, packet);
+    av_packet_unref(packet);
+    if (ret < 0) continue;
+
+    while (ret >= 0) {
+      ret = avcodec_receive_frame(codec_ctx, frame);
+      if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) break;
+      if (ret < 0) {
+        av_frame_unref(frame);
+        av_packet_free(&packet);
+        av_frame_free(&frame);
+        avcodec_free_context(&codec_ctx);
+        avformat_close_input(&format_ctx);
+        return -1;
+      }
+
+      frame_count++;
+      if (frame_count > 500) {
+        av_frame_unref(frame);
+        break;
+      }
+
+      int64_t frame_pts_us = 0;
+      if (frame->pts != AV_NOPTS_VALUE) {
+        AVRational time_base = format_ctx->streams[video_stream_index]->time_base;
+        frame_pts_us = av_rescale_q(frame->pts, time_base, AV_TIME_BASE_Q);
+      }
+
+      if (at_us <= 0 || frame_pts_us >= at_us) {
+        if (frame->width <= 0 || frame->height <= 0) {
+          av_frame_unref(frame);
+          continue;
+        }
+
+        int src_w = frame->width;
+        int src_h = frame->height;
+
+        double scale_w = (double)max_width / src_w;
+        double scale_h = (double)max_height / src_h;
+        double scale = (scale_w < scale_h) ? scale_w : scale_h;
+        if (scale > 1.0) scale = 1.0;
+
+        int thumb_width = (int)(src_w * scale + 0.5);
+        int thumb_height = (int)(src_h * scale + 0.5);
+        if (thumb_width <= 0) thumb_width = 1;
+        if (thumb_height <= 0) thumb_height = 1;
+
+        int rgb_size = av_image_get_buffer_size(AV_PIX_FMT_RGB24, thumb_width, thumb_height, 1);
+        uint8_t* rgb_buffer = (uint8_t*)av_malloc(rgb_size);
+        if (!rgb_buffer) {
+          av_frame_unref(frame);
+          av_packet_free(&packet);
+          av_frame_free(&frame);
+          avcodec_free_context(&codec_ctx);
+          avformat_close_input(&format_ctx);
+          return -1;
+        }
+
+        uint8_t* dst_data[4] = { rgb_buffer, nullptr, nullptr, nullptr };
+        int dst_linesize[4] = { thumb_width * 3, 0, 0, 0 };
+
+        SwsContext* sws_ctx = sws_getContext(
+            src_w, src_h, (AVPixelFormat)frame->format,
+            thumb_width, thumb_height, AV_PIX_FMT_RGB24,
+            SWS_BILINEAR, nullptr, nullptr, nullptr);
+        if (!sws_ctx) {
+          av_free(rgb_buffer);
+          av_frame_unref(frame);
+          av_packet_free(&packet);
+          av_frame_free(&frame);
+          avcodec_free_context(&codec_ctx);
+          avformat_close_input(&format_ctx);
+          return -1;
+        }
+
+        sws_scale(sws_ctx, frame->data, frame->linesize, 0, src_h, dst_data, dst_linesize);
+        sws_freeContext(sws_ctx);
+
+        ret = encode_jpeg_to_buffer(rgb_buffer, thumb_width, thumb_height, quality,
+                                     out_jpeg, out_jpeg_size);
+        av_free(rgb_buffer);
+
+        av_frame_unref(frame);
+        av_packet_free(&packet);
+        av_frame_free(&frame);
+        avcodec_free_context(&codec_ctx);
+        avformat_close_input(&format_ctx);
+
+        if (ret < 0) return -1;
+        return 0;
+      }
+
+      av_frame_unref(frame);
+    }
+
+    if (frame_count > 500) break;
+  }
+
+  av_packet_free(&packet);
+  av_frame_free(&frame);
+  avcodec_free_context(&codec_ctx);
+  avformat_close_input(&format_ctx);
+
+  return -2;
+}
+
+static int parse_args(FlValue* args,
+                      const char** src_file,
+                      int* width,
+                      int* height,
+                      int* quality,
+                      int64_t* at_us) {
+  if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
+    return -1;
+  }
+
+  FlValue* src = fl_value_lookup_string(args, "srcFile");
+  if (!src || fl_value_get_type(src) != FL_VALUE_TYPE_STRING) {
+    return -1;
+  }
+  *src_file = fl_value_get_string(src);
+
+  FlValue* w = fl_value_lookup_string(args, "width");
+  FlValue* h = fl_value_lookup_string(args, "height");
+  if (!w || !h) return -1;
+
+  if (fl_value_get_type(w) == FL_VALUE_TYPE_INT) {
+    *width = (int)fl_value_get_int(w);
+  } else if (fl_value_get_type(w) == FL_VALUE_TYPE_FLOAT) {
+    *width = (int)fl_value_get_float(w);
+  } else {
+    return -1;
+  }
+
+  if (fl_value_get_type(h) == FL_VALUE_TYPE_INT) {
+    *height = (int)fl_value_get_int(h);
+  } else if (fl_value_get_type(h) == FL_VALUE_TYPE_FLOAT) {
+    *height = (int)fl_value_get_float(h);
+  } else {
+    return -1;
+  }
+
+  if (*width <= 0 || *height <= 0) {
+    return -1;
+  }
+
+  *quality = 90;
+  FlValue* q = fl_value_lookup_string(args, "quality");
+  if (q && fl_value_get_type(q) == FL_VALUE_TYPE_INT) {
+    *quality = (int)fl_value_get_int(q);
+    if (*quality < 0) *quality = 0;
+    if (*quality > 100) *quality = 100;
+  }
+
+  *at_us = -1;
+  FlValue* at_us_val = fl_value_lookup_string(args, "atUs");
+  if (at_us_val && fl_value_get_type(at_us_val) == FL_VALUE_TYPE_INT) {
+    *at_us = fl_value_get_int(at_us_val);
+  }
+
+  return 0;
+}
+
+typedef struct {
+  FlMethodCall* method_call;
+  char* src_file;
+  char* dest_file;
+  int width;
+  int height;
+  int quality;
+  int64_t at_us;
+} SaveToFileTaskData;
+
+typedef struct {
+  FlMethodCall* method_call;
+  char* src_file;
+  int width;
+  int height;
+  int quality;
+  int64_t at_us;
+} SaveToBytesTaskData;
+
+static void free_save_to_file_task_data(gpointer data) {
+  SaveToFileTaskData* task_data = (SaveToFileTaskData*)data;
+  if (task_data->method_call) g_object_unref(task_data->method_call);
+  g_free(task_data->src_file);
+  g_free(task_data->dest_file);
+  g_free(task_data);
+}
+
+static void free_save_to_bytes_task_data(gpointer data) {
+  SaveToBytesTaskData* task_data = (SaveToBytesTaskData*)data;
+  if (task_data->method_call) g_object_unref(task_data->method_call);
+  g_free(task_data->src_file);
+  g_free(task_data);
+}
+
+static void save_to_file_thread_func(GTask* task,
+                                      gpointer source_object,
+                                      gpointer task_data,
+                                      GCancellable* cancellable) {
+  SaveToFileTaskData* data = (SaveToFileTaskData*)task_data;
+
+  uint8_t* jpeg_data = nullptr;
+  unsigned long jpeg_size = 0;
+  int result = extract_thumbnail(data->src_file, data->width, data->height, data->quality, data->at_us, &jpeg_data, &jpeg_size);
+
+  FlMethodResponse* response;
+  if (result == -2) {
+    response = make_success_bool(false);
+  } else if (result < 0) {
+    response = make_error(kErrorPluginError, "Failed to extract thumbnail.");
+  } else {
+    FILE* f = fopen(data->dest_file, "wb");
+    if (!f) {
+      free(jpeg_data);
+      response = make_error(kErrorPluginError, "Failed to open destination file.");
+    } else {
+      size_t written = fwrite(jpeg_data, 1, jpeg_size, f);
+      fclose(f);
+      free(jpeg_data);
+      if (written != jpeg_size) {
+        response = make_error(kErrorPluginError, "Failed to write thumbnail to file.");
+      } else {
+        response = make_success_bool(true);
+      }
+    }
+  }
+
+  g_task_return_pointer(task, response, nullptr);
+}
+
+static void save_to_bytes_thread_func(GTask* task,
+                                       gpointer source_object,
+                                       gpointer task_data,
+                                       GCancellable* cancellable) {
+  SaveToBytesTaskData* data = (SaveToBytesTaskData*)task_data;
+
+  uint8_t* jpeg_data = nullptr;
+  unsigned long jpeg_size = 0;
+  int result = extract_thumbnail(data->src_file, data->width, data->height, data->quality, data->at_us, &jpeg_data, &jpeg_size);
+
+  FlMethodResponse* response;
+  if (result == -2) {
+    response = make_null_result();
+  } else if (result < 0) {
+    response = make_error(kErrorPluginError, "Failed to extract thumbnail.");
+  } else {
+    response = make_success_bytes(jpeg_data, jpeg_size);
+    free(jpeg_data);
+  }
+
+  g_task_return_pointer(task, response, nullptr);
+}
+
+static void on_save_to_file_ready(GObject* source, GAsyncResult* result, gpointer user_data) {
+  GTask* task = G_TASK(result);
+  SaveToFileTaskData* data = (SaveToFileTaskData*)g_task_get_task_data(task);
+  g_autoptr(GError) error = nullptr;
+  FlMethodResponse* response = (FlMethodResponse*)g_task_propagate_pointer(task, &error);
+  if (response) {
+    fl_method_call_respond(data->method_call, response, nullptr);
+    g_object_unref(response);
+  }
+}
+
+static void on_save_to_bytes_ready(GObject* source, GAsyncResult* result, gpointer user_data) {
+  GTask* task = G_TASK(result);
+  SaveToBytesTaskData* data = (SaveToBytesTaskData*)g_task_get_task_data(task);
+  g_autoptr(GError) error = nullptr;
+  FlMethodResponse* response = (FlMethodResponse*)g_task_propagate_pointer(task, &error);
+  if (response) {
+    fl_method_call_respond(data->method_call, response, nullptr);
+    g_object_unref(response);
+  }
+}
+
+void save_thumbnail_to_file(FlMethodCall* method_call) {
+  FlValue* args = fl_method_call_get_args(method_call);
+
+  const char* src_file = nullptr;
+  int width = 0, height = 0, quality = 90;
+  int64_t at_us = -1;
+
+  if (parse_args(args, &src_file, &width, &height, &quality, &at_us) < 0) {
+    g_autoptr(FlMethodResponse) response = make_error(kErrorInvalidArgs, "Missing or invalid arguments.");
+    fl_method_call_respond(method_call, response, nullptr);
+    return;
+  }
+
+  FlValue* dest = fl_value_lookup_string(args, "destFile");
+  if (!dest || fl_value_get_type(dest) != FL_VALUE_TYPE_STRING) {
+    g_autoptr(FlMethodResponse) response = make_error(kErrorInvalidArgs, "Missing required argument: destFile.");
+    fl_method_call_respond(method_call, response, nullptr);
+    return;
+  }
+  const char* dest_file = fl_value_get_string(dest);
+
+  SaveToFileTaskData* task_data = g_new0(SaveToFileTaskData, 1);
+  task_data->method_call = (FlMethodCall*)g_object_ref(method_call);
+  task_data->src_file = g_strdup(src_file);
+  task_data->dest_file = g_strdup(dest_file);
+  task_data->width = width;
+  task_data->height = height;
+  task_data->quality = quality;
+  task_data->at_us = at_us;
+
+  GTask* task = g_task_new(nullptr, nullptr, on_save_to_file_ready, nullptr);
+  g_task_set_task_data(task, task_data, free_save_to_file_task_data);
+  g_task_run_in_thread(task, save_to_file_thread_func);
+  g_object_unref(task);
+}
+
+void save_thumbnail_to_bytes(FlMethodCall* method_call) {
+  FlValue* args = fl_method_call_get_args(method_call);
+
+  const char* src_file = nullptr;
+  int width = 0, height = 0, quality = 90;
+  int64_t at_us = -1;
+
+  if (parse_args(args, &src_file, &width, &height, &quality, &at_us) < 0) {
+    g_autoptr(FlMethodResponse) response = make_error(kErrorInvalidArgs, "Missing or invalid arguments.");
+    fl_method_call_respond(method_call, response, nullptr);
+    return;
+  }
+
+  SaveToBytesTaskData* task_data = g_new0(SaveToBytesTaskData, 1);
+  task_data->method_call = (FlMethodCall*)g_object_ref(method_call);
+  task_data->src_file = g_strdup(src_file);
+  task_data->width = width;
+  task_data->height = height;
+  task_data->quality = quality;
+  task_data->at_us = at_us;
+
+  GTask* task = g_task_new(nullptr, nullptr, on_save_to_bytes_ready, nullptr);
+  g_task_set_task_data(task, task_data, free_save_to_bytes_task_data);
+  g_task_run_in_thread(task, save_to_bytes_thread_func);
+  g_object_unref(task);
+}
+
+static void fc_native_video_thumbnail_plugin_handle_method_call(
+    FcNativeVideoThumbnailPlugin* self,
+    FlMethodCall* method_call) {
+  const gchar* method = fl_method_call_get_name(method_call);
+
+  if (strcmp(method, "saveThumbnailToFile") == 0) {
+    save_thumbnail_to_file(method_call);
+  } else if (strcmp(method, "saveThumbnailToBytes") == 0) {
+    save_thumbnail_to_bytes(method_call);
+  } else {
+    g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+    fl_method_call_respond(method_call, response, nullptr);
+  }
+}
+
+static void fc_native_video_thumbnail_plugin_dispose(GObject* object) {
+  G_OBJECT_CLASS(fc_native_video_thumbnail_plugin_parent_class)->dispose(object);
+}
+
+static void fc_native_video_thumbnail_plugin_class_init(FcNativeVideoThumbnailPluginClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = fc_native_video_thumbnail_plugin_dispose;
+}
+
+static void fc_native_video_thumbnail_plugin_init(FcNativeVideoThumbnailPlugin* self) {}
+
+static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+                           gpointer user_data) {
+  FcNativeVideoThumbnailPlugin* plugin = FC_NATIVE_VIDEO_THUMBNAIL_PLUGIN(user_data);
+  fc_native_video_thumbnail_plugin_handle_method_call(plugin, method_call);
+}
+
+void fc_native_video_thumbnail_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
+  FcNativeVideoThumbnailPlugin* plugin = FC_NATIVE_VIDEO_THUMBNAIL_PLUGIN(
+      g_object_new(fc_native_video_thumbnail_plugin_get_type(), nullptr));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) channel =
+      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
+                            "fc_native_video_thumbnail",
+                            FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(channel, method_call_cb,
+                                            g_object_ref(plugin),
+                                            g_object_unref);
+
+  g_object_unref(plugin);
+}

--- a/linux/fc_native_video_thumbnail_plugin_private.h
+++ b/linux/fc_native_video_thumbnail_plugin_private.h
@@ -1,0 +1,7 @@
+#include <flutter_linux/flutter_linux.h>
+
+#include "include/fc_native_video_thumbnail/fc_native_video_thumbnail_plugin.h"
+
+void save_thumbnail_to_file(FlMethodCall* method_call);
+
+void save_thumbnail_to_bytes(FlMethodCall* method_call);

--- a/linux/include/fc_native_video_thumbnail/fc_native_video_thumbnail_plugin.h
+++ b/linux/include/fc_native_video_thumbnail/fc_native_video_thumbnail_plugin.h
@@ -1,0 +1,26 @@
+#ifndef FLUTTER_PLUGIN_FC_NATIVE_VIDEO_THUMBNAIL_PLUGIN_H_
+#define FLUTTER_PLUGIN_FC_NATIVE_VIDEO_THUMBNAIL_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+typedef struct _FcNativeVideoThumbnailPlugin FcNativeVideoThumbnailPlugin;
+typedef struct {
+  GObjectClass parent_class;
+} FcNativeVideoThumbnailPluginClass;
+
+FLUTTER_PLUGIN_EXPORT GType fc_native_video_thumbnail_plugin_get_type();
+
+FLUTTER_PLUGIN_EXPORT void fc_native_video_thumbnail_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar);
+
+G_END_DECLS
+
+#endif  // FLUTTER_PLUGIN_FC_NATIVE_VIDEO_THUMBNAIL_PLUGIN_H_

--- a/linux/test/fc_native_video_thumbnail_plugin_test.cc
+++ b/linux/test/fc_native_video_thumbnail_plugin_test.cc
@@ -1,0 +1,17 @@
+#include <flutter_linux/flutter_linux.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "include/fc_native_video_thumbnail/fc_native_video_thumbnail_plugin.h"
+
+namespace fc_native_video_thumbnail {
+namespace test {
+
+TEST(FcNativeVideoThumbnailPlugin, PluginTypeIsValid) {
+  GType type = fc_native_video_thumbnail_plugin_get_type();
+  ASSERT_NE(type, G_TYPE_INVALID);
+  ASSERT_TRUE(g_type_is_a(type, G_TYPE_OBJECT));
+}
+
+}  // namespace test
+}  // namespace fc_native_video_thumbnail

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,8 @@ flutter:
         sharedDarwinSource: true
       windows:
         pluginClass: FcNativeVideoThumbnailPluginCApi
+      linux:
+        pluginClass: FcNativeVideoThumbnailPlugin
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
Closes #15

Adds Linux platform support using FFmpeg and libjpeg for native video thumbnail extraction.

**Features:**
- Native thumbnail extraction via FFmpeg (`libavformat`, `libavcodec`, `libavutil`, `libswscale`)
- JPEG encoding using `libjpeg` with custom error handling (`setjmp`/`longjmp`)
- Async execution via `g_task_run_in_thread` to avoid blocking the UI thread
- Seeking support with time-based positioning
- 500 frame limit to prevent blocking on corrupt or large files
- Proper memory management (allocator mismatch fixes, correct `av_frame_unref` usage)
- Seek slider in example app with 100ms debounce (hidden on Windows due to lack of seeking support)
- Execution time display for both file and byte outputs

*Note: This PR was almost entirely written with AI assistance, with full human supervision and review.*